### PR TITLE
Add data for granule tests

### DIFF
--- a/gpm_api/etc/product_def.yml
+++ b/gpm_api/etc/product_def.yml
@@ -873,7 +873,7 @@
   pps_nrt_dir: GPROF/MHS
   pps_rs_dir: gprof
   ges_disc_dir: GPM_L2/GPM_2AGPROFMETOPCMHS
-  start_time: 2018-11-16 06:45:21
+  start_time: 2019-07-02 23:18:47
   end_time: null
   available_versions:
   - 5

--- a/gpm_api/tests/dataset/generate_test_granule_data.py
+++ b/gpm_api/tests/dataset/generate_test_granule_data.py
@@ -113,8 +113,6 @@ def find_first_pps_filepath(
     pps_filepaths = find_pps_filepaths(
         product,
         start_time,
-        # start_time gets extended to (start_time - 1 day) in find_pps_filepaths.
-        # May produce "No data found" warning
         end_time,
         product_type=product_type,
     )
@@ -313,7 +311,8 @@ def process_granule(product_basename: str, scan_modes: list[str]):
         processed_granule_filepath = os.path.join(processed_dir_path, f"{scan_mode}.nc")
         try:
             ds = open_granule(granule_path, scan_mode)
-            ds.to_netcdf(processed_granule_filepath)
+            # Must use h5netcdf engine because netCDF does not support booleans in attributes
+            ds.to_netcdf(processed_granule_filepath, engine="h5netcdf", invalid_netcdf=True)
         except Exception as e:
             print(f"Failed to process {product_basename} with scan mode {scan_mode}: {e}")
 

--- a/gpm_api/tests/dataset/test_granule.py
+++ b/gpm_api/tests/dataset/test_granule.py
@@ -153,12 +153,13 @@ def test_open_granule_on_real_files(tmp_path):
 
         for scan_mode in scan_modes:
             ds = granule.open_granule(hdf5_filepath, scan_mode=scan_mode)
-            ds.to_netcdf(test_netcdf_file_path)
+            # Must use h5netcdf engine because netCDF does not support booleans in attributes
+            ds.to_netcdf(test_netcdf_file_path, engine="h5netcdf", invalid_netcdf=True)
             ds = xr.open_dataset(test_netcdf_file_path).compute()
             expected_ds = xr.open_dataset(
                 os.path.join(reference_netcdf_dir_path, f"{scan_mode}.nc")
             ).compute()
-            del ds.attrs["history"]
+            del ds.attrs["history"]  # Current date and time added
             del expected_ds.attrs["history"]
             xr.testing.assert_identical(ds, expected_ds)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ dynamic = ["version"]
 image = ["ximage"]
 dev = ["pre-commit",
        "black[jupyter]", "blackdoc", "codespell", "ruff",
-       "pytest", "pytest-cov", "pytest-mock", "pydantic",
+       "pytest", "pytest-cov", "pytest-mock", "pydantic", "h5netcdf",
        "pytest-watcher", "pip-tools", "bumpver", "twine",
        "setuptools>=61.0.0", "wheel",
        "sphinx", "sphinx-gallery", "sphinx-book-theme", "nbsphinx", "sphinx_mdinclude"]


### PR DESCRIPTION
# Summary

- fix error when saving to netCDF (booleans not supported in attributes)

# To do

- some granules cannot be opened: `ValueError: conflicting sizes for dimension...`
- when ready: push granule data (around 50Mo), test takes several minutes to run (5-10)