### PR TITLE
Fix: find_filepaths non-parallel

### DIFF
--- a/gpm_api/io/filter.py
+++ b/gpm_api/io/filter.py
@@ -89,7 +89,10 @@ def _filter_filepath(filepath, product=None, version=None, start_time=None, end_
 
     """
 
-    info_dict = get_info_from_filepath(filepath)
+    try:
+        info_dict = get_info_from_filepath(filepath)
+    except ValueError:
+        return None
 
     # Filter by version
     if version is not None:

--- a/gpm_api/tests/test_utils/test_list.py
+++ b/gpm_api/tests/test_utils/test_list.py
@@ -10,3 +10,7 @@ def test_flatten_list() -> None:
     assert flatten_list([["double", "item"]]) == ["double", "item"]
     assert flatten_list([]) == [], "Empty list should return empty list"
     assert flatten_list(["single item"]) == ["single item"], "Flat list should return same list"
+    assert flatten_list(["double", "item"]) == [
+        "double",
+        "item",
+    ], "Flat list should return same list"

--- a/gpm_api/utils/list.py
+++ b/gpm_api/utils/list.py
@@ -13,12 +13,10 @@ Created on Thu Oct 26 18:09:38 2023
 def flatten_list(nested_list):
     """Flatten a nested list into a single-level list."""
 
+    if isinstance(nested_list, list) and len(nested_list) == 0:
+        return nested_list
     # If list is already flat, return as is to avoid flattening to chars
-    if (
-        isinstance(nested_list, list)
-        and len(nested_list) == 1
-        and not isinstance(nested_list[0], list)
-    ):
+    if isinstance(nested_list, list) and not isinstance(nested_list[0], list):
         return nested_list
     return (
         [item for sublist in nested_list for item in sublist]


### PR DESCRIPTION
# Summary
- fix `utils/list.py` `flatten_list` method
- fix raised exception when filtering filepath of unknown product
- add test case for `flatten_list`
- add test for `io/find.py` `find_filepaths` method (using `flatten_list`)